### PR TITLE
fix: retirando a obrigatoriedade de retornar uma string no errorMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,5 @@
 		"start": "node --enable-source-maps --inspect --trace-warnings --watch dist",
 		"test": "node --test dist"
 	},
-	"version": "1.1.0"
+	"version": "1.1.1"
 }

--- a/src/utils/CpfCnpjError.ts
+++ b/src/utils/CpfCnpjError.ts
@@ -29,7 +29,7 @@ export type IssueWithDefaultError = Issue & {
 	defaultError: string;
 };
 
-export type ErrorMap = (issue: IssueWithDefaultError) => string;
+export type ErrorMap = (issue: IssueWithDefaultError) => string | undefined;
 
 export default class extends Error {
 	declare issue: IssueWithDefaultError;
@@ -49,7 +49,13 @@ export default class extends Error {
 		};
 
 		if (errorMap) {
-			super(errorMap(_issue));
+			const resultErrorMap = errorMap(_issue);
+
+			if (resultErrorMap) {
+				super(resultErrorMap);
+			} else {
+				super(_issue.defaultError);
+			}
 		} else {
 			super(defaultError);
 		}


### PR DESCRIPTION
Se for retornado um caso para cada tipo, defaultError não existe. Não é mais necessário retornar uma
string

fix #4